### PR TITLE
Make aws cli output configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ like I do:
 (use-package aws-mode
   :load-path "~/.emacs.d/packages/awscli"
   :custom
-  (aws-vault t))
+  (aws-vault t)
+  (aws-output "json")) ;; optional: yaml, json, text (default: yaml)
 
 (use-package aws-evil
   :after (aws-mode evil)

--- a/aws-core.el
+++ b/aws-core.el
@@ -33,6 +33,9 @@
 ;;; Code:
 
 (defun aws-core--tabulated-list-from-command (cmd header)
+  "Displays an aws service list command in a tabulated-list-view.
+CMD is the aws command to get the resources to list.
+HEADER configures the column header for the tabulated-list-view."
   (let ((rows
          (mapcar
           (lambda (x)

--- a/aws-lambda-event-source-mapping.el
+++ b/aws-lambda-event-source-mapping.el
@@ -80,7 +80,7 @@ Used in AWS Lambda Event Source Mapping Mode."
 (defun aws-lambda-event-source-mapping-update (&optional args)
   "Update the Event Source Mapping under the cursor.
 Used in AWS Lambda Event Source Mapping Mode.
-Called from the aws-lambda-event-source-mapping-update-popup transient.
+Called from the 'aws-lambda-event-source-mapping-update-popup' transient.
 ARGS represent the arguments set in the transient."
   (interactive (list (transient-args 'aws-lambda-event-source-mapping-update-popup)))
   (let* ((uuid (tabulated-list-get-id))

--- a/aws-lambda-event-source-mapping.el
+++ b/aws-lambda-event-source-mapping.el
@@ -74,13 +74,8 @@ Current Lambda Function is the one last chosen in AWS Lambda Mode."
   "Describe the Lambda Event Source Mapping under the cursor.
 Used in AWS Lambda Event Source Mapping Mode."
   (interactive)
-  (let* ((uuid (tabulated-list-get-id))
-         (subcmd (concat "lambda get-event-source-mapping --uuid=" uuid))
-         (buffer (concat "*" subcmd "*"))
-         (cmd (concat (aws-cmd) subcmd)))
-    (call-process-shell-command cmd nil buffer)
-    (switch-to-buffer buffer)
-    (with-current-buffer buffer (aws-view-mode))))
+  (let ((cmd "lambda get-event-source-mapping --uuid"))
+    (aws-core--describe-current-resource cmd)))
 
 (defun aws-lambda-event-source-mapping-update (&optional args)
   "Update the Event Source Mapping under the cursor.
@@ -92,13 +87,14 @@ ARGS represent the arguments set in the transient."
          (subcmd
           (concat
            "lambda update-event-source-mapping "
+           "--output=" aws-output
            "--uuid=" uuid " "
            (mapconcat 'identity args " ")))
          (buffer (concat "*" subcmd "*"))
          (cmd (concat (aws-cmd) subcmd)))
     (call-process-shell-command cmd nil buffer)
     (switch-to-buffer buffer)
-    (with-current-buffer buffer (aws-view-mode))))
+    (with-current-buffer buffer (aws--get-view-mode))))
 
 ;; TRANSIENTS
 (transient-define-prefix aws-lambda-event-source-mapping-help-popup ()

--- a/aws-lambda.el
+++ b/aws-lambda.el
@@ -90,9 +90,11 @@ ARGS represent the arguments set in the transient."
     (with-current-buffer buffer (aws-text-view-mode))))
 
 (defun aws-lambda--tmp-outfile (function-name)
+  "Location where the Lambda Function FUNCTION-NAME output is stored."
   (concat "/tmp/aws-el-lambda-" function-name "-output.json"))
 
 (defun aws-lambda-view-last-execution ()
+  "Open the output of the last execution in a buffer."
   (interactive)
   (let* ((function-name (aref (tabulated-list-get-entry) 0))
          (outfile-path (aws-lambda--tmp-outfile function-name)))

--- a/aws-lambda.el
+++ b/aws-lambda.el
@@ -44,14 +44,9 @@
   "Describe the Lambda Function under the cursor.
 This function is used in the AWS Lambda Mode."
   (interactive)
-  (let* ((buffer "*aws.el: lambda-info*")
-        (function-name (aref (tabulated-list-get-entry) 0))
-        (function-desc-cmd
-         (concat (aws-cmd) "lambda get-function --output yaml --function-name " function-name)))
-    (call-process-shell-command function-desc-cmd nil buffer)
-    (switch-to-buffer buffer)
-    (with-current-buffer buffer
-      (aws-view-mode))))
+  (let ((cmd "lambda get-function --function-name"))
+    (aws-core--describe-current-resource cmd)))
+
 
 (defun aws-lambda-get-latest-logs ()
   "Get the latest logs of the Lambda Function under the cursor.
@@ -92,7 +87,7 @@ ARGS represent the arguments set in the transient."
          (cmd (concat (aws-cmd) subcmd)))
     (call-process-shell-command cmd nil buffer)
     (switch-to-buffer buffer)
-    (with-current-buffer buffer (aws-view-mode))))
+    (with-current-buffer buffer (aws-text-view-mode))))
 
 (defun aws-lambda--tmp-outfile (function-name)
   (concat "/tmp/aws-el-lambda-" function-name "-output.json"))

--- a/aws-log-streams.el
+++ b/aws-log-streams.el
@@ -35,6 +35,8 @@
 (defvar-local aws-log-streams-current-group-name nil)
 
 (defun aws-log-streams-get-latest-logs-command (log-group-name &optional count)
+  "Return the aws command to retrieve the latest logs for LOG-GROUP-NAME.
+An optional COUNT ca be passed to limit the maximum amount of log events."
   (let ((max-items-string (if count
                              (concat "--max-items " count)
                            "")))
@@ -46,16 +48,19 @@
             max-items-string)))
 
 (defun aws-log-streams-describe-log-streams (log-group-name)
+  "Tabulated-list-view of the log streams for a given LOG-GROUP-NAME."
   (aws-core--tabulated-list-from-command
    (aws-log-streams-get-latest-logs-command log-group-name)
    [("Log Streams" 100)]))
 
 (defun aws-log-streams-get-log-event-in-view ()
+  "Get the log events for the current log stream."
   (interactive)
   (let ((current-log-stream-name (aref (tabulated-list-get-entry) 0)))
     (aws-log-streams-get-log-event aws-log-streams-current-group-name current-log-stream-name)))
 
 (defun aws-log-streams-get-log-event (log-group log-stream)
+  "Get the log events for the LOG-GROUPs LOG-STREAM."
   (let ((buffer (concat "*" log-group ": " log-stream "*"))
         (cmd (concat
               (aws-cmd)
@@ -83,6 +88,7 @@ Used from the aws-logs mode."
     (aws-log-streams log-group-name)))
 
 (defun aws-log-streams (log-group-name)
+  "List the LOG-GROUP-NAMEs log streams."
   (interactive "slog-group name: ")
   (aws--pop-to-buffer (aws--buffer-name "log-streams"))
   (aws-log-streams-mode)

--- a/aws-log-streams.el
+++ b/aws-log-streams.el
@@ -60,10 +60,11 @@
         (cmd (concat
               (aws-cmd)
               "logs get-log-events --log-group-name '" log-group
-              "' --log-stream-name '" log-stream "'")))
+              "' --log-stream-name '" log-stream "'"
+               " --output=" aws-output)))
     (call-process-shell-command cmd nil buffer)
     (switch-to-buffer buffer)
-    (with-current-buffer buffer (aws-view-mode))))
+    (with-current-buffer buffer (aws--get-view-mode))))
 
 (defvar aws-log-streams-mode-map
   (let ((map (make-sparse-keymap)))

--- a/aws-mode.el
+++ b/aws-mode.el
@@ -46,6 +46,12 @@
                      (split-string
                       (shell-command-to-string "aws configure list-profiles") "\n")))
 
+(defcustom aws-output "yaml"
+  "Defines in which format aws outputs are represented."
+  :type '(string)
+  :group 'aws
+  :options '("yaml" "json" "text"))
+
 (defcustom aws-vault nil
   "Set if aws-vault should be used for aws sessions."
   :type 'symbol
@@ -120,6 +126,13 @@ Use either aws-vault exec or --profile based on setting."
           ((equal service "logs") (aws-logs))
           ((equal service "s3") (aws-s3))
           (t (message "Hello")))))
+
+(defun aws--get-view-mode ()
+  "Return the fitting view mode for aws-output."
+  (cond ((equal aws-output "yaml") (aws-yaml-view-mode))
+        ((equal aws-output "json") (aws-json-view-mode))
+        ((equal aws-output "text") (aws-text-view-mode))
+        (t (message "Invalid aws-output '%s' set! Choose one of ['yaml','json','text']" aws-output))))
 
 ;; MODE-MAP
 (defvar aws-mode-map

--- a/aws-view.el
+++ b/aws-view.el
@@ -36,9 +36,21 @@
     (define-key map (kbd "q") 'kill-current-buffer)
     map))
 
-(define-derived-mode aws-view-mode fundamental-mode "aws-view"
+(define-derived-mode aws-view-yaml-mode yaml-mode "aws-view-yaml"
   "AWS mode"
-  (setq major-mode 'aws-view-mode)
+  (setq major-mode 'aws-view-yaml-mode)
+  (use-local-map aws-view-mode-map)
+  (view-mode))
+
+(define-derived-mode aws-view-json-mode json-mode "aws-view-json"
+  "AWS mode"
+  (setq major-mode 'aws-view-json-mode)
+  (use-local-map aws-view-mode-map)
+  (view-mode))
+
+(define-derived-mode aws-view-text-mode fundamental-mode "aws-view-text"
+  "AWS mode"
+  (setq major-mode 'aws-view-text-mode)
   (use-local-map aws-view-mode-map)
   (view-mode))
 


### PR DESCRIPTION
When yaml or json is chosen, the actual mode is used as well, for better
colorization of the output