### PR TITLE
Add AWS Login Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ commands in the AWS CLI itself.
 
 # Features
 - Switch between your configured profiles
+- Login to the AWS UI via `aws-vault login`
 - Works with the `--profile` flag as well as aws-vault sessions
 - CloudFormation
     - List Stacks

--- a/aws-evil.el
+++ b/aws-evil.el
@@ -50,6 +50,8 @@
 ;; aws-mode
 (evil-define-key 'normal aws-mode-map
   (kbd "RET") #'aws-get-service
+  (kbd "?")   #'aws-help-popup
+  (kbd "L")   #'aws-login-current-account
   (kbd "P")   #'aws-set-profile
   (kbd "q")   #'aws-quit)
 


### PR DESCRIPTION
Utilizes aws-vault login command only currently. Either call the function and
select the profile from a fuzzy find window or login from the aws service view
from the currently active profile